### PR TITLE
Automatic reverts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,41 @@
 # Revertomatic
 
-Tool for reverting pull requests for TRT.  At the moment it doesn't do much
-other than spit out the override commands needed, which is a bit of a pain
-otherwise since you can't easily copy and paste from the GitHub status.
-Eventually it'll try to do as much of the TRT revert workflow as possible,
-including Jira stuff.
+Tool for reverting pull requests for TRT.  
 
 ## Usage
 
-Get a GitHub token and then do this:
-    
+Ensure you have a GitHub token set:
+
 ```
 $ export GITHUB_TOKEN="xyzabcdefgh"
-$ make
-$ ./revertomatic -p https://github.com/openshift/origin/pull/28242 -o
+```
 
-INFO[0000] found info for pr https://github.com/openshift/origin/pull/28242  owner=openshift pr_number=28242 repo=origin
-INFO[0000] Most recent SHA of the PR: 5f853f06192eaff21edc6ade16a77d1e85ba149e 
-INFO[0000] comment this to override ci contexts and force your PR 
-/override ci/prow/e2e-agnostic-ovn-cmd
-/override ci/prow/e2e-metal-ipi-sdn
-/override ci/prow/e2e-metal-ipi-ovn-ipv6
-/override ci/prow/e2e-gcp-ovn
-/override ci/prow/e2e-openstack-ovn
-/override ci/prow/e2e-gcp-csi
-/override ci/prow/e2e-aws-ovn-single-node-upgrade
-/override ci/prow/e2e-aws-ovn-serial
-/override ci/prow/e2e-aws-ovn-cgroupsv2
-/override ci/prow/e2e-aws-csi
-/override ci/prow/e2e-gcp-ovn-rt-upgrade
-/override ci/prow/e2e-gcp-ovn-upgrade
-/override ci/prow/e2e-aws-ovn-upgrade
-/override ci/prow/e2e-aws-ovn-single-node
-/override ci/prow/e2e-aws-ovn-single-node-serial
-/override ci/prow/e2e-aws-ovn-fips
+### No local clone
+
+If you don't have a local copy of the repository already, you can use the
+following command, Revertomatic will create a temporary clone and perform the
+revert. For large repositories (origin, kubernetes) this can take a long time
+and it's better if you have a local clone already (see next section).
+
+```
+./revertomatic \
+    -p https://github.com/openshift/kubernetes/pull/1703 \
+    -j TRT-9999 \
+    -v "Verification steps TBD" \
+    -c "This PR broke all jobs on https://amd64.ocp.releases.ci.openshift.org/releasestream/4.15.0-0.nightly/release/4.15.0-0.nightly-2023-10-03-025546"
+```
+
+### Local clone of Repository
+
+To use a local clone, set -l, -u, and -r settings like this:
+
+```
+./revertomatic \
+    -p https://github.com/openshift/kubernetes/pull/1703 \
+    -j TRT-9999 \
+    -v "Verification steps TBD" \
+    -c "This PR broke all jobs on https://amd64.ocp.releases.ci.openshift.org/releasestream/4.15.0-0.nightly/release/4.15.0-0.nightly-2023-10-03-025546" \
+    -l $HOME/go/src/github.com/kubernetes/kubernetes \
+    -u origin \
+    -r stbenjam
 ```

--- a/cmd/revertomatic.go
+++ b/cmd/revertomatic.go
@@ -10,15 +10,21 @@ import (
 )
 
 var opts struct {
-	prURI    string
-	override bool
-	jira     string
-	context  string
-	verify   string
+	prURI        string
+	override     bool
+	jira         string
+	context      string
+	verify       string
+	localRepo    string
+	forkRemote   string
+	forkUpstream string
 }
 
 func NewCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.prURI, "pr-url", "p", "", "Pull request URL")
+	cmd.Flags().StringVarP(&opts.localRepo, "local-repo", "l", "", "Local copy of the repo, already cloned")
+	cmd.Flags().StringVarP(&opts.forkRemote, "fork-remote", "r", "origin", "Name of the fork remote")
+	cmd.Flags().StringVarP(&opts.forkUpstream, "fork-upstream", "u", "upstream", "Name of the upstream remote")
 	cmd.Flags().StringVarP(&opts.jira, "jira", "j", "", "Jira card tracking the revert")
 	cmd.Flags().StringVarP(&opts.context, "context", "c", "", "Supply context explaining the revert")
 	cmd.Flags().StringVarP(&opts.verify, "verify", "v", "", "Supply details about how to verify a fix (i.e. jobs to run)")

--- a/cmd/revertomatic.go
+++ b/cmd/revertomatic.go
@@ -3,18 +3,10 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
-	"net/url"
-	"os"
-	"regexp"
-	"strconv"
-	"strings"
 
-	"github.com/google/go-github/github"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
-	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openshift-eng/revertomatic/pkg/github"
 )
 
 var opts struct {
@@ -28,101 +20,36 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-var unoveridableJobs = regexp.MustCompile(`.*(unit|lint|images|verify|tide|verify-deps)$`)
-
 var cmd = &cobra.Command{
 	Use:   "revertomatic",
 	Short: "CLI tool to revert a PR",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get the GITHUB_TOKEN environment variable
-		// todo: read from config file
-		githubToken := os.Getenv("GITHUB_TOKEN")
-		if githubToken == "" {
-			cmd.Usage() //nolint
-			return fmt.Errorf("github token required; please set the GITHUB_TOKEN environment variable")
-		}
-
 		if opts.prURI == "" {
 			cmd.Usage() //nolint
 			return fmt.Errorf("no pr url specified")
 		}
-		owner, repo, prNum, err := extractGitHubInfo(opts.prURI)
+
+		client, err := github.New(context.Background())
+		if err != nil {
+			cmd.Usage()
+			return err
+		}
+
+		pr, err := client.ExtractPRInfo(opts.prURI)
 		if err != nil {
 			return err
 		}
 
-		ctx := context.Background()
-
-		// If using a personal access token
-		ts := oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: githubToken},
-		)
-		tc := oauth2.NewClient(ctx, ts)
-
-		client := github.NewClient(tc)
-
-		// Get the PR
-		pr, _, err := client.PullRequests.Get(ctx, owner, repo, prNum)
-		if err != nil {
-			log.Fatalf("Failed to get PR: %v", err)
-		}
-
-		if pr.Head == nil || pr.Head.SHA == nil {
-			log.Fatalf("Failed to retrieve SHA of the PR")
-		}
-
-		sha := *pr.Head.SHA
-		logrus.Infof("Most recent SHA of the PR: %s\n", sha)
-
 		if opts.override {
-			// Get statuses for the SHA
-			statuses, _, err := client.Repositories.ListStatuses(ctx, owner, repo, sha, nil)
+			statuses, err := client.GetOverridableStatuses(pr)
 			if err != nil {
-				log.Fatalf("Failed to get statuses for SHA %s: %v", sha, err)
+				return err
 			}
 
-			uniqueContexts := sets.New[string]()
 			for _, status := range statuses {
-				if status != nil && status.Context != nil && !unoveridableJobs.MatchString(*status.Context) {
-					uniqueContexts.Insert(*status.Context)
-				}
+				fmt.Printf("/override %s\n", status)
 			}
-
-			forceMergeComment := ""
-			for _, c := range uniqueContexts.UnsortedList() {
-				forceMergeComment += fmt.Sprintf("/override %s\n", c)
-			}
-
-			// todo automatically open revert PR and comment overrides
-			logrus.Infof("comment this to override ci contexts and force your PR")
-			fmt.Println(forceMergeComment)
 		}
-
 		return nil
 	},
-}
-
-func extractGitHubInfo(githubURL string) (owner, repo string, prNum int, err error) {
-	u, err := url.Parse(githubURL)
-	if err != nil {
-		return "", "", 0, err
-	}
-
-	// Assuming the URL is correct, we split the path into segments
-	segments := strings.Split(strings.Trim(u.Path, "/"), "/")
-	if len(segments) < 4 || segments[2] != "pull" {
-		return "", "", 0, fmt.Errorf("invalid GitHub PR URL format")
-	}
-
-	fmtNum, err := strconv.Atoi(segments[3])
-	if err != nil {
-		return "", "", 0, err
-	}
-
-	logrus.WithFields(map[string]interface{}{
-		"owner":     segments[0],
-		"repo":      segments[1],
-		"pr_number": fmtNum,
-	}).Infof("found info for pr %s", githubURL)
-	return segments[0], segments[1], fmtNum, nil
 }

--- a/cmd/revertomatic.go
+++ b/cmd/revertomatic.go
@@ -12,11 +12,16 @@ import (
 var opts struct {
 	prURI    string
 	override bool
+	jira     string
+	context  string
+	verify   string
 }
 
 func NewCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.prURI, "pr-url", "p", "", "Pull request URL")
-	cmd.Flags().BoolVarP(&opts.override, "override", "o", false, "Override all required CI (force PR merge)")
+	cmd.Flags().StringVarP(&opts.jira, "jira", "j", "", "Jira card tracking the revert")
+	cmd.Flags().StringVarP(&opts.context, "context", "c", "", "Supply context explaining the revert")
+	cmd.Flags().StringVarP(&opts.verify, "verify", "v", "", "Supply details about how to verify a fix (i.e. jobs to run)")
 	return cmd
 }
 
@@ -27,6 +32,19 @@ var cmd = &cobra.Command{
 		if opts.prURI == "" {
 			cmd.Usage() //nolint
 			return fmt.Errorf("no pr url specified")
+		}
+
+		if opts.jira == "" {
+			cmd.Usage()
+			return fmt.Errorf("required jira field is missing")
+		}
+		if opts.context == "" {
+			cmd.Usage()
+			return fmt.Errorf("required context field is missing")
+		}
+		if opts.verify == "" {
+			cmd.Usage()
+			return fmt.Errorf("required verify field is missing")
 		}
 
 		client, err := github.New(context.Background())
@@ -40,16 +58,20 @@ var cmd = &cobra.Command{
 			return err
 		}
 
-		if opts.override {
-			statuses, err := client.GetOverridableStatuses(pr)
-			if err != nil {
-				return err
-			}
-
-			for _, status := range statuses {
-				fmt.Printf("/override %s\n", status)
-			}
+		if err := client.Revert(pr, opts.jira, opts.context, opts.verify); err != nil {
+			return err
 		}
+
+		fmt.Println("******** After verifying the PR is correct, you can use the comment below to override CI:")
+		statuses, err := client.GetOverridableStatuses(pr)
+		if err != nil {
+			return err
+		}
+
+		for _, status := range statuses {
+			fmt.Printf("/override %s\n", status)
+		}
+
 		return nil
 	},
 }

--- a/cmd/revertomatic.go
+++ b/cmd/revertomatic.go
@@ -31,7 +31,7 @@ func NewCommand() *cobra.Command {
 var unoveridableJobs = regexp.MustCompile(`.*(unit|lint|images|verify|tide|verify-deps)$`)
 
 var cmd = &cobra.Command{
-	Use:   "reveromatic",
+	Use:   "revertomatic",
 	Short: "CLI tool to revert a PR",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get the GITHUB_TOKEN environment variable

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1,0 +1,7 @@
+package v1
+
+type PullRequest struct {
+	Owner      string
+	Repository string
+	Number     int
+}

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -9,3 +9,9 @@ type PullRequest struct {
 	BaseBranch string
 	Author     string
 }
+
+type RepositoryOptions struct {
+	LocalPath      string
+	UpstreamRemote string
+	ForkRemote     string
+}

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -4,4 +4,8 @@ type PullRequest struct {
 	Owner      string
 	Repository string
 	Number     int
+	Title      string
+	MergedSHA  string
+	BaseBranch string
+	Author     string
 }

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -195,7 +195,7 @@ func (c *Client) Revert(prInfo *v1.PullRequest, jira, context, jobs string) erro
 	logrus.Infof("cloning upstream repository...")
 	upstreamURL := fmt.Sprintf("https://github.com/%s/%s.git", prInfo.Owner, prInfo.Repository)
 	// shallow clone for slightly faster reverts
-	err = exec.Command("git", "clone", "--depth", "1", "-b", prInfo.BaseBranch, upstreamURL, tempDir).Run()
+	err = exec.Command("git", "clone", "-b", prInfo.BaseBranch, upstreamURL, tempDir).Run()
 	if err != nil {
 		return err
 	}

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -31,7 +31,9 @@ Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enh
 
 To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:
 
+` + "```" + `
 {{.Jobs}}
+` + "```" + `
 
 CC: @{{.OriginalAuthor}}
 `

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -1,0 +1,116 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	v1 "github.com/openshift-eng/revertomatic/pkg/api/v1"
+)
+
+var unoveridableJobs = regexp.MustCompile(`.*(unit|lint|images|verify|tide|verify-deps)$`)
+
+type Client struct {
+	ctx    context.Context
+	client *github.Client
+}
+
+func New(ctx context.Context) (*Client, error) {
+	// Get the GITHUB_TOKEN environment variable
+	// todo: read from config file
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		return nil, fmt.Errorf("github token required; please set the GITHUB_TOKEN environment variable")
+	}
+
+	// If using a personal access token
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: githubToken},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+
+	return &Client{
+		ctx:    ctx,
+		client: github.NewClient(tc),
+	}, nil
+}
+
+func (c *Client) ExtractPRInfo(githubURL string) (pr *v1.PullRequest, err error) {
+	u, err := url.Parse(githubURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Assuming the URL is correct, we split the path into segments
+	segments := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(segments) < 4 || segments[2] != "pull" {
+		return nil, fmt.Errorf("invalid GitHub PR URL format")
+	}
+
+	fmtNum, err := strconv.Atoi(segments[3])
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.WithFields(map[string]interface{}{
+		"owner":     segments[0],
+		"repo":      segments[1],
+		"pr_number": fmtNum,
+	}).Infof("found info for pr %s", githubURL)
+	return &v1.PullRequest{
+		Owner:      segments[0],
+		Repository: segments[1],
+		Number:     fmtNum,
+	}, nil
+}
+
+func (c *Client) GetOverridableStatuses(prInfo *v1.PullRequest) ([]string, error) {
+	// Get the PR
+	pr, _, err := c.client.PullRequests.Get(c.ctx, prInfo.Owner, prInfo.Repository, prInfo.Number)
+	if err != nil {
+		logrus.WithError(err).WithFields(map[string]interface{}{
+			"owner": prInfo.Owner,
+			"repo":  prInfo.Repository,
+			"prNum": prInfo.Number,
+		}).Warn("failed to get PR")
+		return nil, err
+	}
+
+	if pr.Head == nil || pr.Head.SHA == nil {
+		log.Fatalf("Failed to retrieve SHA of the PR")
+	}
+
+	sha := *pr.Head.SHA
+	logrus.Infof("Most recent SHA of the PR: %s\n", sha)
+
+	// Get statuses for the SHA
+	statuses, _, err := c.client.Repositories.ListStatuses(c.ctx, prInfo.Owner, prInfo.Repository, sha, nil)
+	if err != nil {
+		logrus.WithError(err).WithFields(map[string]interface{}{
+			"owner": prInfo.Owner,
+			"repo":  prInfo.Repository,
+			"prNum": prInfo.Number,
+			"sha":   sha,
+		}).Warn("failed to get statuses")
+		return nil, err
+	}
+
+	uniqueStatuses := sets.New[string]()
+	for _, status := range statuses {
+		if status != nil && status.Context != nil && !unoveridableJobs.MatchString(*status.Context) {
+			uniqueStatuses.Insert(*status.Context)
+		}
+	}
+
+	return uniqueStatuses.UnsortedList(), nil
+}

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -194,7 +194,8 @@ func (c *Client) Revert(prInfo *v1.PullRequest, jira, context, jobs string) erro
 	// Clone the upstream repository
 	logrus.Infof("cloning upstream repository...")
 	upstreamURL := fmt.Sprintf("https://github.com/%s/%s.git", prInfo.Owner, prInfo.Repository)
-	err = exec.Command("git", "clone", upstreamURL, tempDir).Run()
+	// shallow clone for slightly faster reverts
+	err = exec.Command("git", "clone", "--depth", "1", "-b", prInfo.BaseBranch, upstreamURL, tempDir).Run()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Example revert PR: 
https://github.com/openshift/origin/pull/28280

![image](https://github.com/stbenjam/revertomatic/assets/429763/fbf2ee1d-968c-419e-8cfb-6176e131aca3)


TODO's
- [ ] Show output of git commands as they run
- [ ] Use existing clones of repos instead of always cloning (configurable setting?) - takes forever for some repos (i.e. origin)
- [ ] Handle unclean reverts (provide helpful error message)
- [ ] Handle edge cases (i.e. renamed repo forks) if possible
